### PR TITLE
Make nav section links go to first child

### DIFF
--- a/main.html
+++ b/main.html
@@ -312,8 +312,8 @@ A copy of the License has been included in the root of the repository.
       <nav>
         <ul>
         {% for section in nav -%}
-        <li class="toc-section"><a href="{{ section.url|url }}">{{ section.title }}</a></li>
           {% if section.children -%}
+          <li class="toc-section"><a href="{{ section.children[0].url|url }}">{{ section.title }}</a></li>
           {% for chapter in section.children -%}
             <li class="toc-chapter
               {% if chapter.meta.mono_title %} mono{% endif -%}
@@ -331,6 +331,8 @@ A copy of the License has been included in the root of the repository.
             {% endfor -%}
             {% endif -%}
           {% endfor -%}
+          {% else -%}
+          <li class="toc-section"><a href="{{ section.url|url }}">{{ section.title }}</a></li>
           {% endif -%}
         {% endfor -%}
         </ul>


### PR DESCRIPTION
Before this change, any section in the sidebar with children would
link to the root of the project.
    
I saw two choices here:
    
 1. Don't create an anchor tag for sections.
 2. Link to the first child of the section.
    
I went with option 2 because it ensures that there is visual and UX
consistency for the navigation links.

- - -

You can see the current behavior in action on: https://ruuda.github.io/tako/distributing-images/

The `User guide`, `Reference`, and `Internals` links in the sidebar all currently link to https://ruuda.github.io/tako/ where I wouldn't expect that myself.