### PR TITLE
Add support for mono page titles

### DIFF
--- a/main.html
+++ b/main.html
@@ -129,6 +129,16 @@ A copy of the License has been included in the root of the repository.
     font-family: 'Roboto Mono', monospace;
     font-size: 0.84rem;
     line-height: 1.59rem;
+    font-weight: 500;
+  }
+  h1 > code {
+    font-size: 2rem;
+  }
+  h2 > code {
+    font-size: 1.59rem;
+  }
+  h3 > code {
+    font-size: 1rem;
   }
   .mono {
     font-family: 'Roboto Mono', monospace;
@@ -148,7 +158,6 @@ A copy of the License has been included in the root of the repository.
   }
   p > code,
   a > code,
-  h3 > code,
   li > code,
   td > code {
     background-color: #f0f0f0;
@@ -161,9 +170,6 @@ A copy of the License has been included in the root of the repository.
   h3 {
     margin-top: 2.29rem;
     margin-bottom: 0.89rem;
-  }
-  h3 > code {
-    margin-left: -0.1rem;
   }
   a {
     color: #36d;


### PR DESCRIPTION
We don't have access to the way that MkDocs renders Markdown, but we do want consistent monospace titles. Therefore, we make an assumption that there will only be one h1 on a doc page, and make it monospace for those specific pages.